### PR TITLE
Bugfix/xml

### DIFF
--- a/JM/CF/XML/3_Game/XML/CF_XML_Document.c
+++ b/JM/CF/XML/3_Game/XML/CF_XML_Document.c
@@ -136,13 +136,17 @@ class CF_XML_Document : CF_XML_Element
 					return true;
 				}
 
-				string content = "";
+				string content = c;
 
 				while (true)
 				{
-					c = _reader.GetCharacter();
+					bool wasNewLine = _reader.WasNewLine();
+					if (wasNewLine) c = _reader.SkipWhitespace();
+					else c = _reader.GetCharacter();
+
 					if (c != "<")
 					{
+						if (wasNewLine) content += "\n";
 						content += c;
 						continue;
 					}
@@ -150,6 +154,7 @@ class CF_XML_Document : CF_XML_Element
 					c = _reader.GetCharacter();
 					if (c != "/")
 					{
+						if (wasNewLine) content += "\n";
 						content += "<";
 						content += c;
 						continue;
@@ -162,6 +167,8 @@ class CF_XML_Document : CF_XML_Element
 					
 					if (tagName != _currentTag.GetName())
 					{
+						if (wasNewLine) content += "\n";
+						content += "<";
 						content += c;
 						_reader.SetPosition(posA, posB);
 						continue;

--- a/JM/CF/XML/3_Game/XML/CF_XML_Document.c
+++ b/JM/CF/XML/3_Game/XML/CF_XML_Document.c
@@ -129,6 +129,58 @@ class CF_XML_Document : CF_XML_Element
 			}
 			else if (c == ">")
 			{
+				c = _reader.SkipWhitespace();
+				if (c == "<")
+				{
+					c = _reader.BackChar();
+					return true;
+				}
+
+				string content = "";
+
+				while (true)
+				{
+					c = _reader.GetCharacter();
+					if (c != "<")
+					{
+						content += c;
+						continue;
+					}
+					
+					c = _reader.GetCharacter();
+					if (c != "/")
+					{
+						content += "<";
+						content += c;
+						continue;
+					}
+					
+					int posA, posB;
+					_reader.GetPosition(posA, posB);
+
+					tagName = _reader.GetWord();
+					
+					if (tagName != _currentTag.GetName())
+					{
+						content += c;
+						_reader.SetPosition(posA, posB);
+						continue;
+					}
+				
+					break;
+				}
+
+				_currentTag.GetContent().SetContent(content);
+
+				c = _reader.GetCharacter();
+				if (c != ">")
+				{
+					_reader.Err("Expected '>' for closing tag, got: " + c);
+				}
+
+				PopTag();
+
+				return true;
 			}
 			else
 			{

--- a/JM/CF/XML/3_Game/XML/CF_XML_Element.c
+++ b/JM/CF/XML/3_Game/XML/CF_XML_Element.c
@@ -107,6 +107,10 @@ class CF_XML_Element : Managed
 
 	void OnWrite(FileHandle handle, int depth)
 	{
+		string indent = CF_XML_Indent(depth);
+
+		FPrint(handle, _data);
+
 		for (int i = 0; i < _tags.Count(); ++i)
 		{
 			_tags[i].OnWrite(handle, depth);

--- a/JM/CF/XML/3_Game/XML/CF_XML_Reader.c
+++ b/JM/CF/XML/3_Game/XML/CF_XML_Reader.c
@@ -5,6 +5,8 @@ class CF_XML_Reader : Managed
 	private int _arrIdx = 0;
 	private int _bufIdx = -1;
 
+	private bool _wasNewLine;
+
 	private ref array<string> _lines;
 
 	void CF_XML_Reader()
@@ -40,8 +42,15 @@ class CF_XML_Reader : Managed
 			_lines.Insert(line);
 	}
 
+	bool WasNewLine()
+	{
+		return _wasNewLine;
+	}
+
 	string BackChar()
 	{
+		_wasNewLine = false;
+
 		_bufIdx--;
 		if (_bufIdx < 0)
 		{
@@ -55,11 +64,15 @@ class CF_XML_Reader : Managed
 			_bufIdx = _lines[_arrIdx].Length() - 1;
 		}
 
+		if (_bufIdx == 0) _wasNewLine = true;
+
 		return _lines[_arrIdx].SubstringUtf8(_bufIdx, 1);
 	}
 
 	private string ReadChar()
 	{
+		_wasNewLine = false;
+
 		_bufIdx++;
 
 		if (_bufIdx >= _lines[_arrIdx].Length())
@@ -67,6 +80,8 @@ class CF_XML_Reader : Managed
 			_bufIdx = 0;
 
 			_arrIdx++;
+
+			_wasNewLine = true;
 
 			if (_arrIdx >= _lines.Count())
 			{

--- a/JM/CF/XML/3_Game/XML/CF_XML_Reader.c
+++ b/JM/CF/XML/3_Game/XML/CF_XML_Reader.c
@@ -16,6 +16,18 @@ class CF_XML_Reader : Managed
 	{
 		delete _lines;
 	}
+	
+	void GetPosition(out int arrIdx, out int bufIdx)
+	{
+		arrIdx = _arrIdx;
+		bufIdx = _bufIdx;
+	}
+	
+	void SetPosition(out int arrIdx, out int bufIdx)
+	{
+		_arrIdx = arrIdx;
+		_bufIdx = bufIdx;
+	}
 
 	void Err(string message)
 	{


### PR DESCRIPTION
Fixes xml content not being read properly, sometimes causing crashes

e.g. would cause crash:

```xml
<state>
    <event_update>
        time += DeltaTime;
        if (time < 1.0) return REEVALUTATE;
        time = 0;
        return CONTINUE;
    </event_update>
</state>
```