### PR TITLE
Made modstorage opt-in

### DIFF
--- a/JM/CF/ModStorage/4_World/CF_ModStorage/CF_ModStorage_Object.c
+++ b/JM/CF/ModStorage/4_World/CF_ModStorage/CF_ModStorage_Object.c
@@ -15,7 +15,7 @@ class CF_ModStorage_Object<Class T>
 
 		ctx.Write(CF_ModStorage.VERSION);
 		
-		array<ref ModStructure> mods = ModLoader.GetMods();
+		array<ref ModStructure> mods = ModLoader.Get_ModStorage_Mods();
 
 		int i;
 		int count = mods.Count() + m_UnloadedMods.Count();
@@ -62,7 +62,7 @@ class CF_ModStorage_Object<Class T>
 			if (!ctx.Read(modName)) return false;
 
 			ModStructure mod;
-			bool modExists = ModLoader.Find(modName, mod);
+			bool modExists = ModLoader.Find_ModStorage_Mod(modName, mod);
 
 			CF_ModStorage store = new CF_ModStorage(mod, modName);
 
@@ -83,7 +83,7 @@ class CF_ModStorage_Object<Class T>
 			// Add to the unloaded mods array so the data is resaved when the entity is saved.
 			// This is for when a server owner may want to add back in a mod they removed which
 			// may have wanted to keep some data.
-			if (!modExists) m_UnloadedMods.Insert(store);
+			if (!modExists && !ModLoader.Contains(modName)) m_UnloadedMods.Insert(store);
 		}
 
 		return true;

--- a/JM/CF/Scripts/3_Game/CommunityFramework/Mods/ModLoader.c
+++ b/JM/CF/Scripts/3_Game/CommunityFramework/Mods/ModLoader.c
@@ -2,10 +2,19 @@ modded class ModLoader
 {
 	private static ref map<string, ModStructure> m_ModMap = new map<string, ModStructure>();
 
+	private static ref array<ref ModStructure> m_CF_ModStorage_Mods;
+	private static ref map<string, ModStructure> m_CF_ModStorage_ModMap = new map<string, ModStructure>();
+
 	static ref ModStructure Get(string name)
 	{
 		if (!m_Loaded) LoadMods();
-		return m_ModMap[name];
+		return m_CF_ModStorage_ModMap[name];
+	}
+
+	static bool Contains(string name)
+	{
+		if (!m_Loaded) LoadMods();
+		return m_ModMap.Contains(name);
 	}
 
 	static bool Find(string name, out ModStructure mod)
@@ -14,15 +23,28 @@ modded class ModLoader
 		return m_ModMap.Find(name, mod);
 	}
 
+	static bool Find_ModStorage_Mod(string name, out ModStructure mod)
+	{
+		if (!m_Loaded) LoadMods();
+		return m_CF_ModStorage_ModMap.Find(name, mod);
+	}
+
 	override static array<ref ModStructure> GetMods()
 	{
 		if (!m_Loaded) LoadMods();
 		return m_Mods;
 	}
 
+	static array<ref ModStructure> Get_ModStorage_Mods()
+	{
+		if (!m_Loaded) LoadMods();
+		return m_CF_ModStorage_Mods;
+	}
+
 	override static void LoadMods()
 	{
 		m_Mods = new array<ref ModStructure>;
+		m_CF_ModStorage_Mods = new array<ref ModStructure>;
 
 		int mod_count = GetGame().ConfigGetChildrenCount("CfgMods");
 
@@ -36,6 +58,24 @@ modded class ModLoader
 			m_Mods.Insert(mod);
 
 			m_ModMap.Insert(mod_name, mod);
+
+			if (!GetGame().ConfigIsExisting("CfgMods " + mod_name + " CF_ModStorage"))
+			{
+				Print("Ignoring " + mod_name + " for CF_ModStorage");
+				continue;
+			}
+
+			if (!GetGame().ConfigGetInt("CfgMods " + mod_name + " CF_ModStorage"))
+			{
+				Print("Ignoring " + mod_name + " for CF_ModStorage");
+				continue;
+			}
+
+			Print("Adding " + mod_name + " for CF_ModStorage");
+
+			m_CF_ModStorage_Mods.Insert(mod);
+
+			m_CF_ModStorage_ModMap.Insert(mod_name, mod);
 		}
 
 		m_Loaded = true;


### PR DESCRIPTION
This makes modstorage opt-in to solve performance problems and storage size blowing up.

Mods that wish to use modstorage have to add `CF_ModStorage = 1` under their respective CfgMods entry, e.g.
```
class CfgMods
{
	class DZ_Expansion_Vehicles
	{
		...
		CF_ModStorage = 1;
		...
	}
};
```