### PR TITLE
Fixed RespawnEventTypeID calling wrong CF event

### DIFF
--- a/JM/CF/Scripts/3_Game/CommunityFramework/Game/DayZGame.c
+++ b/JM/CF/Scripts/3_Game/CommunityFramework/Game/DayZGame.c
@@ -161,7 +161,7 @@ modded class DayZGame
 			RespawnEventParams respawnParams;
 			if (Class.CastTo(respawnParams, params))
 			{
-				CF_ModuleCoreManager.OnMPConnectionLost(this, new CF_EventTimeArgs(respawnParams.param1));
+				CF_ModuleCoreManager.OnRespawn(this, new CF_EventTimeArgs(respawnParams.param1));
 			}
 			break;
 		}


### PR DESCRIPTION
Fixed OnMPConnectionLost getting called instead of OnRespawn when processing RespawnEventTypeID