### PR TITLE
Use ToAscii instead of Hash

### DIFF
--- a/JM/CF/Scripts/1_Core/CommunityFramework/CF_Byte.c
+++ b/JM/CF/Scripts/1_Core/CommunityFramework/CF_Byte.c
@@ -37,7 +37,7 @@ class CF_Byte : CF_Uint
 
 	static CF_Byte Set(string char)
 	{
-		CF_Byte byte = char[0].Hash() & 255;
+		CF_Byte byte = char[0].ToAscii() & 255;
 		return byte;
 	}
 

--- a/JM/CF/Scripts/1_Core/CommunityFramework/CF_Byte.c
+++ b/JM/CF/Scripts/1_Core/CommunityFramework/CF_Byte.c
@@ -37,7 +37,7 @@ class CF_Byte : CF_Uint
 
 	static CF_Byte Set(string char)
 	{
-		CF_Byte byte = char[0].ToAscii() & 255;
+		CF_Byte byte = char.Get(0).ToAscii() & 255;
 		return byte;
 	}
 

--- a/JM/CF/Scripts/1_Core/CommunityFramework/IO/CF_BinaryWriter.c
+++ b/JM/CF/Scripts/1_Core/CommunityFramework/IO/CF_BinaryWriter.c
@@ -25,7 +25,7 @@ class CF_BinaryWriter : CF_IO
 
 	override void WriteChar(string value)
 	{
-		m_Stream.AppendCurrent(value.Hash());
+		m_Stream.AppendCurrent(value.ToAscii());
 	}
 
 	override void WriteBool(bool value)
@@ -94,7 +94,7 @@ class CF_BinaryWriter : CF_IO
 		
 		for (int i = 0; i < value.Length(); i++)
 		{
-			m_Stream.AppendCurrent(value.Substring(i, 1).Hash());
+			m_Stream.AppendCurrent(value[i].ToAscii());
 		}
 	}
 
@@ -102,7 +102,7 @@ class CF_BinaryWriter : CF_IO
 	{
 		for (int i = 0; i < value.Length(); i++)
 		{
-			m_Stream.AppendCurrent(value.Substring(i, 1).Hash());
+			m_Stream.AppendCurrent(value[i].ToAscii());
 		}
 		
 		m_Stream.AppendCurrent(0);

--- a/JM/CF/Scripts/1_Core/CommunityFramework/IO/CF_BinaryWriter.c
+++ b/JM/CF/Scripts/1_Core/CommunityFramework/IO/CF_BinaryWriter.c
@@ -94,7 +94,7 @@ class CF_BinaryWriter : CF_IO
 		
 		for (int i = 0; i < value.Length(); i++)
 		{
-			m_Stream.AppendCurrent(value[i].ToAscii());
+			m_Stream.AppendCurrent(value.Substring(i, 1).ToAscii());
 		}
 	}
 

--- a/JM/CF/Scripts/1_Core/CommunityFramework/IO/CF_BinaryWriter.c
+++ b/JM/CF/Scripts/1_Core/CommunityFramework/IO/CF_BinaryWriter.c
@@ -94,7 +94,7 @@ class CF_BinaryWriter : CF_IO
 		
 		for (int i = 0; i < value.Length(); i++)
 		{
-			m_Stream.AppendCurrent(value.Substring(i, 1).ToAscii());
+			m_Stream.AppendCurrent(value.Get(i).ToAscii());
 		}
 	}
 
@@ -102,7 +102,7 @@ class CF_BinaryWriter : CF_IO
 	{
 		for (int i = 0; i < value.Length(); i++)
 		{
-			m_Stream.AppendCurrent(value[i].ToAscii());
+			m_Stream.AppendCurrent(value.Get(i).ToAscii());
 		}
 		
 		m_Stream.AppendCurrent(0);

--- a/JM/CF/Scripts/1_Core/CommunityFramework/IO/CF_StringStream.c
+++ b/JM/CF/Scripts/1_Core/CommunityFramework/IO/CF_StringStream.c
@@ -9,7 +9,7 @@ class CF_StringStream : CF_Stream
 		m_String = str;
 		for (int i = 0; i < str.Length(); i++)
 		{
-			Append(str[i].Hash());
+			Append(str[i].ToAscii());
 		}
 		
 		Seek(0, CF_SeekOrigin.SET);

--- a/JM/CF/Scripts/1_Core/CommunityFramework/IO/CF_StringStream.c
+++ b/JM/CF/Scripts/1_Core/CommunityFramework/IO/CF_StringStream.c
@@ -9,7 +9,7 @@ class CF_StringStream : CF_Stream
 		m_String = str;
 		for (int i = 0; i < str.Length(); i++)
 		{
-			Append(str[i].ToAscii());
+			Append(str.Get(i).ToAscii());
 		}
 		
 		Seek(0, CF_SeekOrigin.SET);

--- a/JM/CF/Scripts/1_Core/CommunityFramework/IO/CF_TextWriter.c
+++ b/JM/CF/Scripts/1_Core/CommunityFramework/IO/CF_TextWriter.c
@@ -17,7 +17,7 @@ class CF_TextWriter : CF_IO
 
 	override void WriteChar(string value)
 	{
-		WriteByte(value.Hash());
+		WriteByte(value.ToAscii());
 	}
 	
 	override void WriteBool(bool value)

--- a/JM/CF/Scripts/3_Game/CommunityFramework/ExpressionVM/CF_Expression.c
+++ b/JM/CF/Scripts/3_Game/CommunityFramework/ExpressionVM/CF_Expression.c
@@ -60,7 +60,7 @@ class CF_Expression
 
 	protected bool IsAlphanumeric( string c )
 	{
-		int i = c.Hash();
+		int i = c.ToAscii();
 		
 		if (i >= 42 && i <= 57)
 			return true;
@@ -76,7 +76,7 @@ class CF_Expression
 
 	protected bool IsLetterOrDigit( string c )
 	{
-		int i = c.Hash();
+		int i = c.ToAscii();
 			
 		if ( i >= 48 && i <= 57 )
 			return true;
@@ -140,7 +140,7 @@ class CF_Expression
 
 		for ( int i = 0; i < word.Length(); i++ )
 		{
-			int c = word[i].Hash();
+			int c = word[i].ToAscii();
 			if ( c == 46 )
 			{
 				if ( decimal )

--- a/JM/CF/Scripts/3_Game/CommunityFramework/ExpressionVM/CF_Expression.c
+++ b/JM/CF/Scripts/3_Game/CommunityFramework/ExpressionVM/CF_Expression.c
@@ -140,14 +140,15 @@ class CF_Expression
 
 		for ( int i = 0; i < word.Length(); i++ )
 		{
-			int c = word[i].ToAscii();
+			int c = word.Get(i).ToAscii();
 			if ( c == 46 )
 			{
 				if ( decimal )
 					return false;
 				
 				decimal = true;
-			} else if ( !( c >= 48 && c <= 57 ) )
+			} 
+			else if ( !( c >= 48 && c <= 57 ) )
 			{
 				return false;
 			}

--- a/JM/CF/Scripts/3_Game/CommunityFramework/XML/CF_XML_Reader.c
+++ b/JM/CF/Scripts/3_Game/CommunityFramework/XML/CF_XML_Reader.c
@@ -208,7 +208,7 @@ class CF_XML_Reader : Managed
 
 	bool IsLetterOrDigit(string c, bool isQuoted)
 	{
-		int i = c.Hash();
+		int i = c.ToAscii();
 		if (i >= 255 || i < 0) //! To my dear @DaOne, please don't use UTF-8 characters :)
 			return true;
 


### PR DESCRIPTION
Stops using Hash to get a single character string ascii value, and uses ToAscii as this is now linked properly in script vm.