### PR TITLE
Fix CF_Stream::SetPositionAtStart

### DIFF
--- a/JM/CF/Scripts/1_Core/CommunityFramework/IO/CF_Stream.c
+++ b/JM/CF/Scripts/1_Core/CommunityFramework/IO/CF_Stream.c
@@ -221,7 +221,7 @@ class CF_Stream
 	void SetPositionAtStart()
 	{
 		m_Current = m_Head;
-		m_Position = -1;
+		m_Position = 0;
 	}
 
 	void SetPositionAtEnd()

--- a/JM/CF/Scripts/1_Core/CommunityFramework/IO/CF_Stream.c
+++ b/JM/CF/Scripts/1_Core/CommunityFramework/IO/CF_Stream.c
@@ -220,7 +220,7 @@ class CF_Stream
 
 	void SetPositionAtStart()
 	{
-		m_Current = null;
+		m_Current = m_Head;
 		m_Position = -1;
 	}
 


### PR DESCRIPTION
Fixes first byte being read being always zero. Makes CF_SHA256 work correctly.