### PR TITLE
Fixed various issues with XML reading and writing

### DIFF
--- a/JM/CF/Scripts/3_Game/CommunityFramework/XML/CF_XML_Attribute.c
+++ b/JM/CF/Scripts/3_Game/CommunityFramework/XML/CF_XML_Attribute.c
@@ -109,9 +109,9 @@ class CF_XML_Attribute : Managed
 
 	void OnWrite(FileHandle handle, int depth)
 	{
-		FPrint(handle, _name);
+		FPrint(handle, " " + _name);
 		FPrint(handle, "=\"");
 		FPrint(handle, _value);
-		FPrint(handle, "\" ");
+		FPrint(handle, "\"");
 	}
 };

--- a/JM/CF/Scripts/3_Game/CommunityFramework/XML/CF_XML_Element.c
+++ b/JM/CF/Scripts/3_Game/CommunityFramework/XML/CF_XML_Element.c
@@ -38,9 +38,9 @@ class CF_XML_Element : Managed
 		return element;
 	}
 
-	CF_XML_Tag CreateTag(string name)
+	CF_XML_Tag CreateTag(string name, bool isProcessingInstruction = false)
 	{
-		CF_XML_Tag tag = new CF_XML_Tag(this, name);
+		CF_XML_Tag tag = new CF_XML_Tag(this, name, false, isProcessingInstruction);
 
 		_tags.Insert(tag);
 
@@ -109,11 +109,22 @@ class CF_XML_Element : Managed
 	{
 		string indent = CF_XML_Indent(depth);
 
-		FPrint(handle, _data);
+		if (_data)
+			FPrintln(handle, EncodeEntities(_data));
 
 		for (int i = 0; i < _tags.Count(); ++i)
 		{
 			_tags[i].OnWrite(handle, depth);
 		}
+	}
+
+	static string EncodeEntities(string content)
+	{
+		//! Order matters
+		content.Replace("&", "&amp;");
+		content.Replace("<", "&lt;");
+		content.Replace(">", "&gt;");
+
+		return content;
 	}
 };

--- a/JM/CF/Scripts/3_Game/CommunityFramework/XML/CF_XML_Reader.c
+++ b/JM/CF/Scripts/3_Game/CommunityFramework/XML/CF_XML_Reader.c
@@ -70,7 +70,7 @@ class CF_XML_Reader : Managed
 
 		if (_bufIdx == 0) _wasNewLine = true;
 
-		return _lines[_arrIdx].SubstringUtf8(_bufIdx, 1);
+		return _lines[_arrIdx].Substring(_bufIdx, 1);
 	}
 
 	private string ReadChar()
@@ -93,7 +93,7 @@ class CF_XML_Reader : Managed
 			}
 		}
 
-		return _lines[_arrIdx].SubstringUtf8(_bufIdx, 1);
+		return _lines[_arrIdx].Substring(_bufIdx, 1);
 	}
 
 	bool EOF()

--- a/JM/CF/Scripts/config.cpp
+++ b/JM/CF/Scripts/config.cpp
@@ -47,7 +47,8 @@ class CfgMods
             "CF_SURFACES",
             "CF_MODULES",
             "CF_REF_FIX",
-            "CF_BUGFIX_REF" // Same as CF_REF_FIX but for mods that already anticipated a different name
+            "CF_BUGFIX_REF", // Same as CF_REF_FIX but for mods that already anticipated a different name
+            "CF_BUGFIX_XML"
         };
         
 		dependencies[] = { "Core", "Game", "World", "Mission" };


### PR DESCRIPTION
- Fixed reader using SubstringUtf8 when it shouldn't
- Fixed long text in tags getting truncated due to vanilla bug with string.Replace (T177558)
- Fixed attributes not being written in the order they were read (making comparisons hard)
- Fixed reading/writing XML declaration (and other XML processing directives)
- Fixed writing element text data
- Fixed writing closing tags