### PR TITLE
bugfix: fix private variable access in ConfigClass causing compile

### DIFF
--- a/JM/CF/Scripts/3_Game/CommunityFramework/Config/ConfigClass.c
+++ b/JM/CF/Scripts/3_Game/CommunityFramework/Config/ConfigClass.c
@@ -45,6 +45,10 @@ class ConfigClass : ConfigEntry
 		return this;
 	}
 
+	void SetBase(ConfigClass new_base) {
+		_base = new_base;
+	}
+
 	ConfigClass GetBase()
 	{
 		return _base;
@@ -61,9 +65,9 @@ class ConfigClass : ConfigEntry
 
 		ConfigEntry possibleEntry = NULL;
 
-		if ( _parent.GetClass()._base != NULL )
+		if ( _parent.GetClass().GetBase() != NULL )
 		{
-			possibleEntry = _parent.GetClass()._base.Find( name, true, true );
+			possibleEntry = _parent.GetClass().GetBase().Find( name, true, true );
 		}
 
 		if ( possibleEntry == NULL && _parent._parent != NULL )
@@ -187,7 +191,7 @@ class ConfigClass : ConfigEntry
 							return false;
 						}
 
-						entry.GetClass()._base = baseEntry.GetClass();
+						entry.GetClass().SetBase(baseEntry.GetClass());
 						c = reader.GetCharacter();
 					}
 


### PR DESCRIPTION
Despite the GetClass method returning an instance of ConfigClass we can't access a private variable from outside the class instance.

The diag build of the game refused to compile, not certain whether it is an issue on the retail version but we can fix it by using the appropriate setters anyway.

<img width="401" height="169" alt="CF-Bug-02" src="https://github.com/user-attachments/assets/53cc2001-6ec2-4d19-873b-9eefda67c17c" />
